### PR TITLE
Remove mod section from the application file

### DIFF
--- a/src/ssl_verify_hostname.app.src
+++ b/src/ssl_verify_hostname.app.src
@@ -9,7 +9,6 @@
                   stdlib,
                   ssl
                  ]},
-  {mod, { ssl_verify_hostname_app, []}},
   {env, []}
  ]}.
 


### PR DESCRIPTION
This is a library app so it doesn't need a mod section in .app.src file.