### PR TITLE
Don't include unused file.

### DIFF
--- a/src/ssl_verify_hostname.erl
+++ b/src/ssl_verify_hostname.erl
@@ -6,7 +6,6 @@
 
 -module(ssl_verify_hostname).
 -include_lib("public_key/include/public_key.hrl").
--include_lib("ssl/src/ssl_alert.hrl").
 
 
 -export([verify_fun/3, verify_cert_hostname/2]).


### PR DESCRIPTION
ssl/src/ssl_alert.hrl adds a dependency to a file that is not normally
installed in a non-developer environment.

Furthermore, nothing from the file is used.