### PR TITLE
Include application specification for mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,18 +1,19 @@
 defmodule SSLVerifyFun.Mixfile do
   use Mix.Project
 
+  {:ok, [{:application, :ssl_verify_fun, props}]} = :file.consult("src/ssl_verify_fun.app.src")
+  @props Keyword.take(props, [:applications, :description, :env, :mod, :vsn])
+
+  def application do
+    @props
+  end
+
   def project do
     [app: :ssl_verify_fun,
      language: :erlang,
      version: "1.1.6",
-     description: description(),
+     description: to_string(@props[:description]),
      package: package()]
-  end
-
-  defp description() do
-    """
-    SSL verification functions for Erlang
-    """
   end
 
   defp package() do


### PR DESCRIPTION
Without this fix, ssl_verify_fun.erl can fail to compile
or run in Elixir, as it won't include the important :ssl
dependency.