### PR TITLE
fix annotated type variables with distinct types

### DIFF
--- a/src/ssl_verify_fingerprint.erl
+++ b/src/ssl_verify_fingerprint.erl
@@ -27,8 +27,8 @@
 -spec verify_fun(Cert :: #'OTPCertificate'{},
                  Event :: {bad_cert, Reason :: atom() | {revoked, atom()}} |
                           {extension, #'Extension'{}}, InitialUserState :: term()) ->
-                    {valid, UserState :: term()} | {valid_peer, UserState :: user_state()} |
-                    {fail, Reason :: term()} | {unknown, UserState :: term()}.
+                    {valid, ValidUserState :: term()} | {valid_peer, UserState :: user_state()} |
+                    {fail, Reason :: term()} | {unknown, UnknownUserState :: term()}.
 verify_fun(_, {extension, _}, UserState) ->
   {unknown, UserState};
 verify_fun(Cert, _, UserState) ->

--- a/src/ssl_verify_hostname.erl
+++ b/src/ssl_verify_hostname.erl
@@ -30,8 +30,8 @@
                           {extension, #'Extension'{}} |
                           valid | valid_peer,
                  InitialUserState :: term()) ->
-                    {valid, UserState :: term()} | {valid_peer, UserState :: user_state()} |
-                    {fail, Reason :: term()} | {unknown, UserState :: term()}.
+                    {valid, ValidUserState :: term()} | {valid_peer, UserState :: user_state()} |
+                    {fail, Reason :: term()} | {unknown, UnknownUserState :: term()}.
 verify_fun(_, {bad_cert, _} = Reason, _) ->
   {fail, Reason};
 verify_fun(_, {extension, _}, UserState) ->

--- a/src/ssl_verify_pk.erl
+++ b/src/ssl_verify_pk.erl
@@ -26,8 +26,8 @@
 -spec verify_fun(Cert :: #'OTPCertificate'{},
                  Event :: {bad_cert, Reason :: atom() | {revoked, atom()}} |
                           {extension, #'Extension'{}}, InitialUserState :: term()) ->
-                    {valid, UserState :: term()} | {valid_peer, UserState :: user_state()} |
-                    {fail, Reason :: term()} | {unknown, UserState :: term()}.
+                    {valid, ValidUserState :: term()} | {valid_peer, UserState :: user_state()} |
+                    {fail, Reason :: term()} | {unknown, UnknownUserState :: term()}.
 verify_fun(Cert, {bad_cert, selfsigned_peer}, UserState) ->
   maybe_verify_cert_pk(Cert, UserState);
 verify_fun(_Cert, {bad_cert, unknown_ca}, UserState) ->


### PR DESCRIPTION
as per OTP pull request [#7717](https://github.com/erlang/otp/pull/7717), duplicate annotation variables that have different types will not be allowed in OTP-27.

this PR simply re-writes the type specification so that it is compliant with the OTP change.